### PR TITLE
Allow 'list' to be an alias of 'hand'

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ time that can be left off and the bot will work it out.
     Repeat the text of the current Black Card.
 
 *   `[#channel] hand`
+    `[#channel] list`
 
     Provides a numbered list of the White Cards in the player's hand.
 

--- a/lib/PAH.pm
+++ b/lib/PAH.pm
@@ -150,6 +150,10 @@ sub BUILD {
           sub        => \&do_priv_hand,
           privileged => 1,
       },
+      'list' => {
+          sub        => \&do_priv_hand,
+          privileged => 1,
+      },
       'black' => {
           sub        => \&do_priv_black,
           privileged => 0,


### PR DESCRIPTION
The 'hand' command provides a numeric _list_ of the
players white cards.  I think it is reasonable to
expect the verb 'list' to be an alias to 'hand'.

Signed-off-by: Dave Walker (Daviey) email@daviey.com
