### PR TITLE
add the white cards from the Main Game

### DIFF
--- a/packs/cah_uk.yml
+++ b/packs/cah_uk.yml
@@ -593,7 +593,7 @@ White:
     - a thousand Scottish warriors lifting their kilts in unison
     - edible underwear
     - my collection of high-tech sex toys
-    - The Force
+    - the Force
     - Buckfast Tonic Wine
     - Tories
     - a micropig wearing a tiny raincoat and booties

--- a/packs/cah_us.yml
+++ b/packs/cah_us.yml
@@ -1,0 +1,469 @@
+---
+# This is a YAML-formatted document.
+# Read more about YAML here:
+#
+#   http://www.yaml.org/
+
+Description:    Cards Against Humanity
+License:        Creative Commons BY-NC-SA 2.0
+Copyright:      Cards Against Humanity LLC
+
+# Warning: this pack is incompatible with the UK edition.
+#          Using both packs simultaneously will result in many duplicate cards.
+
+White:
+    - flying sex snakes
+    - Michelle Obama's arms
+    - German dungeon porn
+    - white people
+    - getting so angry that you pop a boner
+    - tasteful sideboob
+    - praying the gay away
+    - two midgets shitting into a bucket
+    - MechaHitler
+    - being a motherfucking sorcerer
+    - a disappointing birthday party
+    - puppies!
+    - a windmill full of corpses
+    - guys who don't call
+    - racially-biased SAT questions
+    - dying
+    - Steven Hawking talking dirty
+    - being on fire
+    - a lifetime of sadness
+    - an erection that lasts longer than four hours
+    - AIDS
+    - same-sex ice dancing
+    - Glenn Beck catching his scrotum on a curtain hook
+    - the Rapture
+    - pterodactyl eggs
+    - roofies
+    - getting naked and watching Nickelodeon
+    - the forbidden fruit
+    - Republicans
+    - the Big Bang
+    - anal beads
+    - amputees
+    - men
+    - surprise sex!
+    - Kim Jong-il
+    - concealing a boner
+    - agriculture
+    - Glenn Beck being harried by a swarm of buzzards
+    - making a pouty face
+    - a salty surprise
+    - the Jews
+    - charisma
+    - YOU MUST CONSTRUCT ADDITIONAL PYLONS
+    - panda sex
+    - taking off your shirt
+    - a drive-by shooting
+    - Ronald Regan
+    - Morgan Freeman's voice
+    - breaking out into song and dance
+    - Jewish fraternities
+    - dead babies
+    - masturbation
+    - hormone injections
+    - all-you-can-eat shrimp for $4.99
+    - incest
+    - scalping
+    - soup that is too hot
+    - the Übermensch
+    - Nazis
+    - Tom Cruise
+    - stifling a giggle at the mention of Hutus and Tutsis
+    - edible underpants
+    - the Hustle
+    - a Super Soaker™ full of cat piss
+    - figgy pudding
+    - object permanence
+    - consultants
+    - intelligent design
+    - nocturnal emissions
+    - uppercuts
+    - being marginalized
+    - the profoundly handicapped
+    - obesity
+    - chutzpah
+    - unfathomable stupidity
+    - repression
+    - attitude
+    - passable transvestites
+    - party poopers
+    - the American Dream
+    - child beauty pageants
+    - puberty
+    - testicular torsion
+    - the folly of man
+    - Nickelback
+    - swooping
+    - goats eating cans
+    - the KKK
+    - kamikaze pilots
+    - horrifying laser hair removal accidents
+    - Adderall™
+    - a look-see
+    - doing the right thing
+    - the taint; the grundle; the fleshy fun-bridge
+    - the invisible hand
+    - lactation
+    - Pabst Blue Ribbon
+    - powerful thighs
+    - saxophone solos
+    - the gays
+    - a middle-aged man on roller skates
+    - a foul mouth
+    - that thing that electrocutes your abs
+    - heteronormativity
+    - cuddling
+    - coat hanger abortions
+    - a big hoopla about nothing
+    - boogers
+    - a hot mess
+    - raptor attacks
+    - my collection of high-tech sex toys
+    - fear itself
+    - bees?
+    - getting drunk on mouthwash
+    - sniffing glue
+    - oversized lollipops
+    - an icepick lobotomy
+    - being rich
+    - friends with benefits
+    - teaching a robot to love
+    - women's suffrage
+    - me time
+    - the heart of a child
+    - smallpox blankets
+    - the clitoris
+    - John Wilkes Booth
+    - the glass ceiling
+    - Sarah Palin
+    - sexy pillow fights
+    - yeast
+    - full frontal nudity
+    - parting the Red Sea
+    - a Bop It™
+    - Michael Jackson
+    - team-building exercises
+    - Harry Potter erotica
+    - authentic Mexican cuisine
+    - frolicking
+    - sexting
+    - Grandma
+    - not giving a shit about the Third World
+    - licking things to claim them as your own
+    - Genghis Khan
+    - the hardworking Mexican
+    - RoboCop
+    - my relationship status
+    - scrubbing under the folds
+    - porn stars
+    - horse meat
+    - sunshine and rainbows
+    - expecting a burp and vomiting on the floor
+    - Barack Obama
+    - spontaneous human combusion
+    - natural selection
+    - mouth herpes
+    - flash flooding
+    - goblins
+    - a monkey smoking a sigar
+    - spectacular abs
+    - a good sniff
+    - wiping her butt
+    - the Three-Fifths compromise
+    - pedophiles
+    - doin' it in the butt
+    - being fabulous
+    - matheletes
+    - wearing underwear inside-out to avoid doing laundry
+    - nipple blades
+    - an M. Night Shyamalan plot twist
+    - a bag of magic beans
+    - vigorous jazz hands
+    - a defective condom
+    - Skeletor
+    - Vikings
+    - leaving an awkward voicemail
+    - teenage pregnancy
+    - dead parents
+    - hot cheese
+    - my sex life
+    - a mopey zoo lion
+    - assless chaps
+    - riding off into the sunset
+    - Lance Armstrong's missing testicle
+    - sweet, sweet vengeance
+    - genital piercings
+    - keg stands
+    - Darth Vader
+    - Viagra®
+    - necrophilia
+    - a really cool hat
+    - Toni Morrison's vagina
+    - an Oedipus complex
+    - the Tempur-Pedic® Swedish Sleep System™
+    - preteens
+    - dick fingers
+    - a cooler full of organs
+    - shapeshifters
+    - the Care Bear Stare
+    - erectile dysfunction
+    - Keanu Reeves
+    - the Virginia Tech Massacre
+    - the Underground Railroad
+    - the chronic
+    - queefing
+    - heartwarming orphans
+    - a thermonuclear detonation
+    - cheating in the Special Olympics
+    - tangled Slinkys
+    - a moment of silence
+    - civilian casualties
+    - catapults
+    - sharing needles
+    - ethnic cleansing
+    - children on leashes
+    - balls
+    - homeless people
+    - eating all of the cooklies before the AIDS bake-sale
+    - old-people smell
+    - farting and walking away
+    - the inevitable heat death of the universe
+    - my humps
+    - the violation of our most basic human rights
+    - fingering
+    - the placenta
+    - the Rev. Dr. Martin Luther King, Jr.
+    - leprosy
+    - sperm whales
+    - multiple stab wounds
+    - flightless birds
+    - grave robbing
+    - home video of Oprah sobbing into a Lean Cuisine®
+    - Oompa-Loompas
+    - a murder most foul
+    - tentacle porn
+    - daddy issues
+    - Bill Nye the Science Guy
+    - peeing a little bit
+    - the miracle of childbirth
+    - "Tweeting"
+    - another goddamn vampire movie
+    - Britney Spears at 55
+    - New Age music
+    - the Make-A-Wish® Foundation
+    - firing a rifle into the air while balls deep in a squealing hog
+    - active listening
+    - Nicolas Cage
+    - 72 virgins
+    - stranger danger
+    - hope
+    - a gassy antelope
+    - BATMAN!!!
+    - Chivalry
+    - passing a kidney stone
+    - black people
+    - Natalie Portman
+    - a mime having a stroke
+    - classist undertones
+    - Sean Penn
+    - a mating display
+    - the Holy Bible
+    - Hot Pockets®
+    - a sad handjob
+    - pulling out
+    - serfdom
+    - pixelated bukkake
+    - dropping a chandelier on your enemies and riding the rope up
+    - Jew-fros
+    - waiting 'til marriage
+    - Euphoria™ by Calvin Klein
+    - the World of Warcraft
+    - Lunchables™
+    - the Kool-Aid Man
+    - the Trail of Tears
+    - self-loathing
+    - a falcon with a cap on its head
+    - historically black colleges
+    - not reciprocating oral sex
+    - global warming
+    - ghosts
+    - world peace
+    - a can of whoop-ass
+    - the Dance of the Sugar Plum Fairy
+    - a zesty breakfast burrito
+    - switching to Geico®
+    - Aaron Burr
+    - picking up girls at the abortion clinic
+    - land mines
+    - former President George W. Bush
+    - geese
+    - mutually-assured destruction
+    - college
+    - date rape
+    - bling
+    - a gentle caress of the inner thigh
+    - a time travel paradox
+    - seppuku
+    - poor life choices
+    - waking up half-naked in a Denny's parking lot
+    - Italians
+    - GoGurt®
+    - finger painting
+    - Robert Downey, Jr.
+    - my soul
+    - smegma
+    - embryonic stem cells
+    - the South
+    - Christopher Walken
+    - gloryholes
+    - pretending to care
+    - public ridicule
+    - a tiny horse
+    - Arnold Schwarzenegger
+    - a stray pube
+    - jerking off into a pool of children's tears
+    - child abuse
+    - Glenn Beck convulsively vomiting as a brood of crab spiders hatches in his brain and erupts from his tear ducts
+    - menstruation
+    - a sassy black woman
+    - re-gifting
+    - penis envy
+    - a sausage festival
+    - getting really high
+    - drinking alone
+    - too much hair gel
+    - Hulk Hogan
+    - overcompensation
+    - foreskin
+    - free samples
+    - Shaquille O'Neal's acting career
+    - Five-Dollar Footlongs™
+    - whipping it out
+    - a snapping turtle biting the tip of your penis
+    - Muhammad (Praise Be Unto Him)
+    - half-assed foreplay
+    - dental dams
+    - being a dick to children
+    - famine
+    - chainsaws for hands
+    - a Gypsy curse
+    - AXE Body Spray
+    - the Force
+    - explosions
+    - cybernetic enhancements
+    - customer service representatives
+    - white privilege
+    - Gandhi
+    - road head
+    - God
+    - poorly timed Holocaust jokes
+    - 8 oz. of sweet Mexican black-tar heroin
+    - Judge Judy
+    - the Little Engine That Could
+    - altar boys
+    - Mr. Clean, right behind you
+    - vehicular manslaughter
+    - dwarf tossing
+    - friction
+    - Lady Gaga
+    - Scientology
+    - Justin Bieber
+    - a death ray
+    - Vigilante justice
+    - the Pope
+    - a sea of troubles
+    - alcoholism
+    - poor people
+    - a feuts
+    - women in yogurt commercials
+    - exactly what you'd expect
+    - flesh-eating bacteria
+    - my genitals
+    - a balanced breakfast
+    - Dick Cheney
+    - lockjaw
+    - natural male enhancement
+    - take-backsies
+    - winking at old people
+    - opposable thumbs
+    - flying sex snakes
+    - passive-aggressive Post-it notes
+    - inappropriate yodeling
+    - golden showers
+    - racism
+    - copping a feel
+    - Auschwitz
+    - elderly Japanese men
+    - raping and pillaging
+    - kids with ass cancer
+    - pictures of boobs
+    - the homosexual agenda
+    - a homoerotic volleyball montage
+    - sexual tension
+    - Hurricane Katrina
+    - fiery poops
+    - science
+    - dry heaving
+    - Cards Against Humanity
+    - Fancy Feast®
+    - a bleached asshole
+    - lumberjack fantasies
+    - American gladiators
+    - autocannibalism
+    - Sean Connery
+    - William Shatner
+    - Domino's™ Oreo™ Dessert Pizza
+    - an asymmetric boob job
+    - centaurs
+    - a micropenis
+    - asians who aren't good at math
+    - the milk man
+    - waterboarding
+    - wifely duties
+    - loose lips
+    - the Blood of Christ
+    - actually taking candy from a baby
+    - the token minority
+    - jibber-jabber
+    - a brain tumor
+    - bingeing and purgin
+    - a clandestine butt scratch
+    - the Chinese gymnastics team
+    - prancing
+    - the Hamburgular
+    - police brutality
+    - man meat
+    - forgetting the Alamo
+    - eating the last known bison
+    - crystal meth
+    - booby-trapping the house to foil burglars
+    - my inner demons
+    - third base
+    - soiling oneself
+    - laying an egg
+    - giving 110%
+    - hot people
+    - friendly fire
+    - Count Chocula
+    - Pac-Man uncontrollably guzzling cum
+    - estrogen
+    - my vagina
+    - Kanye West
+    - a robust mongoloid
+    - the Donald Trump Seal of Approval™
+    - the true meaning of Christmas
+    - Her Royal Highness, Queen Elizabeth II
+    - an honest cop with nothing left to lose
+    - feeding Rosie O'Donnell
+    - the Amish
+    - the Terrorists
+    - when you fart and a little bit comes out
+    - pooping back and forth. Forever.
+    - friends who eat all the snacks
+    - cockfights
+    - bitches
+    - seduction

--- a/packs/cah_us_uk.yml
+++ b/packs/cah_us_uk.yml
@@ -1,0 +1,192 @@
+---
+# This is a YAML-formatted document.
+# Read more about YAML here:
+#
+#   http://www.yaml.org/
+
+Description:    Cards Against Humanity (US \ UK)
+License:        Creative Commons BY-NC-SA 2.0
+Copyright:      Cards Against Humanity LLC
+
+# This pack is the relative compliment of the UK pack in the US pack.
+# It is intended to be used in conjunction with the UK pack to add the
+# additional American cards. It is incompatible with the US pack.
+
+White:
+    - Michelle Obama's arms
+    - guys who don't call
+    - racially-biased SAT questions
+    - Steven Hawking talking dirty
+    - Glenn Beck catching his scrotum on a curtain hook
+    - the Rapture
+    - pterodactyl eggs
+    - roofies
+    - getting naked and watching Nickelodeon
+    - the forbidden fruit
+    - Republicans
+    - Kim Jong-il
+    - concealing a boner
+    - Glenn Beck being harried by a swarm of buzzards
+    - charisma
+    - a drive-by shooting
+    - Ronald Regan
+    - breaking out into song and dance
+    - Jewish fraternities
+    - all-you-can-eat shrimp for $4.99
+    - scalping
+    - the Übermensch
+    - stifling a giggle at the mention of Hutus and Tutsis
+    - edible underpants
+    - the Hustle
+    - figgy pudding
+    - consultants
+    - intelligent design
+    - nocturnal emissions
+    - uppercuts
+    - obesity
+    - chutzpah
+    - attitude
+    - passable transvestites
+    - party poopers
+    - goats eating cans
+    - Adderall™
+    - a look-see
+    - the taint; the grundle; the fleshy fun-bridge
+    - the invisible hand
+    - Pabst Blue Ribbon
+    - saxophone solos
+    - that thing that electrocutes your abs
+    - heteronormativity
+    - a big hoopla about nothing
+    - boogers
+    - a hot mess
+    - bees?
+    - getting drunk on mouthwash
+    - friends with benefits
+    - smallpox blankets
+    - John Wilkes Booth
+    - Sarah Palin
+    - parting the Red Sea
+    - a Bop It™
+    - team-building exercises
+    - authentic Mexican cuisine
+    - sexting
+    - the hardworking Mexican
+    - scrubbing under the folds
+    - porn stars
+    - spontaneous human combusion
+    - flash flooding
+    - goblins
+    - a monkey smoking a sigar
+    - wiping her butt
+    - the Three-Fifths compromise
+    - pedophiles
+    - doin' it in the butt
+    - matheletes
+    - wearing underwear inside-out to avoid doing laundry
+    - Skeletor
+    - leaving an awkward voicemail
+    - assless chaps
+    - genital piercings
+    - keg stands
+    - Toni Morrison's vagina
+    - the Tempur-Pedic® Swedish Sleep System™
+    - the Care Bear Stare
+    - the Virginia Tech Massacre
+    - the Underground Railroad
+    - the chronic
+    - queefing
+    - cheating in the Special Olympics
+    - tangled Slinkys
+    - a moment of silence
+    - sharing needles
+    - eating all of the cooklies before the AIDS bake-sale
+    - home video of Oprah sobbing into a Lean Cuisine®
+    - Bill Nye the Science Guy
+    - "Tweeting"
+    - another goddamn vampire movie
+    - Britney Spears at 55
+    - the Make-A-Wish® Foundation
+    - active listening
+    - stranger danger
+    - Chivalry
+    - passing a kidney stone
+    - Hot Pockets®
+    - pixelated bukkake
+    - Jew-fros
+    - Euphoria™ by Calvin Klein
+    - Lunchables™
+    - the Kool-Aid Man
+    - the Trail of Tears
+    - historically black colleges
+    - global warming
+    - a can of whoop-ass
+    - the Dance of the Sugar Plum Fairy
+    - a zesty breakfast burrito
+    - switching to Geico®
+    - Aaron Burr
+    - picking up girls at the abortion clinic
+    - former President George W. Bush
+    - college
+    - date rape
+    - bling
+    - GoGurt®
+    - Robert Downey, Jr.
+    - the South
+    - jerking off into a pool of children's tears
+    - >
+        Glenn Beck convulsively vomiting as a brood of crab spiders
+        hatches in his brain and erupts from his tear ducts
+    - menstruation
+    - re-gifting
+    - a sausage festival
+    - too much hair gel
+    - Hulk Hogan
+    - Shaquille O'Neal's acting career
+    - Five-Dollar Footlongs™
+    - half-assed foreplay
+    - dental dams
+    - a Gypsy curse
+    - customer service representatives
+    - road head
+    - Judge Judy
+    - the Little Engine That Could
+    - Mr. Clean, right behind you
+    - vehicular manslaughter
+    - dwarf tossing
+    - a death ray
+    - Vigilante justice
+    - a feuts
+    - Dick Cheney
+    - Auchwitz
+    - raping and pillaging
+    - Hurricane Katrina
+    - fiery poops
+    - Fancy Feast®
+    - a bleached asshole
+    - American gladiators
+    - Domino's™ Oreo™ Dessert Pizza
+    - centaurs
+    - asians who aren't good at math
+    - waterboarding
+    - loose lips
+    - actually taking candy from a baby
+    - jibber-jabber
+    - bingeing and purging
+    - a clandestine butt scratch
+    - the Hamburgular
+    - forgetting the Alamo
+    - eating the last known bison
+    - booby-trapping the house to foil burglars
+    - third base
+    - soiling oneself
+    - Count Chocula
+    - Kanye West
+    - the Donald Trump Seal of Approval™
+    - an honest cop with nothing left to lose
+    - feeding Rosie O'Donnell
+    - the Amish
+    - the Terrorists
+    - friends who eat all the snacks
+    - cockfights
+    - seduction


### PR DESCRIPTION
The mainline Cards Against Humanity has just under 200 cards that the UK edition doesn't have, including one of my favourites. This commit adds the US original set as a .yml file, and includes a second file containing the cards the US has that the UK doesn't (allowing it to be used more easily in existing games).

To create the second file, I removed the duplicates, tried to get rid of as many with minor spelling differences ("oversized lollipop"/"oversized lollipops"; "being marginalized"/"being marginalised") as I could find, and some of the obviously translated ones ("Denny's parking lot"/"Little Chef car park"). I left the rest, including the ones I didn't understand. Up to you if you want to excise them, or perhaps fix Cards Against Humanity's frankly unhealthy obsession with Glenn Beck...
