### PR TITLE
Correct spelling in cah_us

### DIFF
--- a/packs/cah_us.yml
+++ b/packs/cah_us.yml
@@ -164,12 +164,12 @@ White:
     - sunshine and rainbows
     - expecting a burp and vomiting on the floor
     - Barack Obama
-    - spontaneous human combusion
+    - spontaneous human combustion
     - natural selection
     - mouth herpes
     - flash flooding
     - goblins
-    - a monkey smoking a sigar
+    - a monkey smoking a cigar
     - spectacular abs
     - a good sniff
     - wiping her butt

--- a/packs/cah_us_uk.yml
+++ b/packs/cah_us_uk.yml
@@ -8,7 +8,7 @@ Description:    Cards Against Humanity (US \ UK)
 License:        Creative Commons BY-NC-SA 2.0
 Copyright:      Cards Against Humanity LLC
 
-# This pack is the relative compliment of the UK pack in the US pack.
+# This pack is the relative complement of the UK pack in the US pack.
 # It is intended to be used in conjunction with the UK pack to add the
 # additional American cards. It is incompatible with the US pack.
 
@@ -74,10 +74,10 @@ White:
     - the hardworking Mexican
     - scrubbing under the folds
     - porn stars
-    - spontaneous human combusion
+    - spontaneous human combustion
     - flash flooding
     - goblins
-    - a monkey smoking a sigar
+    - a monkey smoking a cigar
     - wiping her butt
     - the Three-Fifths compromise
     - pedophiles
@@ -158,7 +158,7 @@ White:
     - Vigilante justice
     - a fetus
     - Dick Cheney
-    - Auchwitz
+    - Auschwitz
     - raping and pillaging
     - Hurricane Katrina
     - fiery poops


### PR DESCRIPTION
And remove now-duplicated entries from cah_us_uk complementary pack.
