### PR TITLE
Remove now-duplicated entries from cah_us_uk complementary pack

### DIFF
--- a/packs/cah_us_uk.yml
+++ b/packs/cah_us_uk.yml
@@ -163,7 +163,6 @@ White:
     - a bleached asshole
     - American gladiators
     - Domino's™ Oreo™ Dessert Pizza
-    - centaurs
     - asians who aren't good at math
     - waterboarding
     - loose lips

--- a/packs/cah_us_uk.yml
+++ b/packs/cah_us_uk.yml
@@ -30,7 +30,6 @@ White:
     - charisma
     - a drive-by shooting
     - Ronald Reagan
-    - breaking out into song and dance
     - Jewish fraternities
     - all-you-can-eat shrimp for $4.99
     - scalping

--- a/packs/cah_us_uk.yml
+++ b/packs/cah_us_uk.yml
@@ -74,10 +74,8 @@ White:
     - the hardworking Mexican
     - scrubbing under the folds
     - porn stars
-    - spontaneous human combustion
     - flash flooding
     - goblins
-    - a monkey smoking a cigar
     - wiping her butt
     - the Three-Fifths compromise
     - pedophiles
@@ -158,7 +156,6 @@ White:
     - Vigilante justice
     - a fetus
     - Dick Cheney
-    - Auschwitz
     - raping and pillaging
     - Hurricane Katrina
     - fiery poops


### PR DESCRIPTION
Builds on top of #160.

Only merge once card removals can be handled.
