### PR TITLE
Remove 'centaurs' from US/UK complement pack

### DIFF
--- a/packs/cah_us_uk.yml
+++ b/packs/cah_us_uk.yml
@@ -166,7 +166,6 @@ White:
     - a bleached asshole
     - American gladiators
     - Domino's™ Oreo™ Dessert Pizza
-    - centaurs
     - asians who aren't good at math
     - waterboarding
     - loose lips


### PR DESCRIPTION
It's already in the UK pack with different capitalisation.
