### PR TITLE
[cas500] Fix "grammar type" of one of the black cards

### DIFF
--- a/packs/cas500.yml
+++ b/packs/cas500.yml
@@ -127,7 +127,7 @@ Black:
         2. _________
         3. _________
     - 'Science: Doing its part to help humanity, one _______ at a time.'
-    - I can't believe I get paid to _______.
+    - I can't believe I get paid for _______.
     - After I defended, my advisor gave me ________.
     - Congratulations! Your fellowship includes a stipend and _______.
     - '_________: Don''t go to a conference without it.'


### PR DESCRIPTION
Most (all?) white cards are nouns (and the ones that describe
activities are usually gerunds), but the phrasing of this black card
expected a verb which makes it grammatically incompatible with most
white cards.

Changing 'to' to 'for' makes a lot more sense at least with the cards
that I currently hold on #BitFolk